### PR TITLE
update documentation for reading a custom spec

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -420,7 +420,7 @@ An typespec consists mainly in `ISpec` protocol that has two methods: `read` and
 (buf/write! buffer mypoint point-spec)
 ;; => 8
 
-(buf/read* buffer (point))
+(buf/read* buffer point-spec)
 ;; => [8 #user.Point{:x 1, :y 2}]
 ----
 
@@ -441,7 +441,7 @@ Let see how the previous code can be simplified in much less boilerplate code:
 (buf/write! buffer mypoint point-spec)
 ;; => 8
 
-(buf/read* buffer (point))
+(buf/read* buffer point-spec)
 ;; => [8 #user.Point{:x 1, :y 2}]
 ----
 


### PR DESCRIPTION
The code sample as written throws a runtime exception, I think the final parameter here ought to be `point-spec`.

```
user=> (buf/write! buffer mypoint point-spec)
8
user=> (buf/read* buffer (point))

CompilerException java.lang.RuntimeException: Unable to resolve symbol: point in this context, compiling:(/private/var/folders/c_/l9wcwrgd27vb53w7z138fyjr0000gp/T/form-init3457715331949550778.clj:1:19) 
user=> (buf/read* buffer point-spec)
[8 #user.Point{:x 1, :y 2}]
```
