### PR TITLE
Fix CLJS compiler warnings about undeclared vars

### DIFF
--- a/src/octet/buffer.cljc
+++ b/src/octet/buffer.cljc
@@ -86,11 +86,12 @@
 
 ;; ---- NIO & Netty Buffer implementations
 
-(defn- set-current-bytebuffer-byte-order!
-  [buff]
-  (case *byte-order*
-    :big-endian (.order buff ByteOrder/BIG_ENDIAN)
-    :little-endian (.order buff ByteOrder/LITTLE_ENDIAN)))
+#?(:clj
+   (defn- set-current-bytebuffer-byte-order!
+     [buff]
+     (case *byte-order*
+       :big-endian (.order buff ByteOrder/BIG_ENDIAN)
+       :little-endian (.order buff ByteOrder/LITTLE_ENDIAN))))
 
 #?(:clj
    (extend-type ByteBuffer


### PR DESCRIPTION
```
WARNING: No such namespace: ByteOrder, could not locate ByteOrder.cljs, ByteOrder.cljc, or Closure namespace "" at line 92 resources/public/js/compiled/out/octet/buffer.cljc
WARNING: Use of undeclared Var ByteOrder/BIG_ENDIAN at line 92 resources/public/js/compiled/out/octet/buffer.cljc
WARNING: No such namespace: ByteOrder, could not locate ByteOrder.cljs, ByteOrder.cljc, or Closure namespace "" at line 93 resources/public/js/compiled/out/octet/buffer.cljc
WARNING: Use of undeclared Var ByteOrder/LITTLE_ENDIAN at line 93 resources/public/js/compiled/out/octet/buffer.cljc
```

Fixed the above warnings.