### PR TITLE
support for ref specs, fixed issue with assoc spec, added hex-dump, set version to 1.0.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/octet "1.0.1"
+(defproject funcool/octet "1.0.2"
   :description "A clojure(script) library for work with binary data."
   :url "https://github.com/funcool/octet"
   :license {:name "Public Domain"

--- a/src/octet/core.cljc
+++ b/src/octet/core.cljc
@@ -32,6 +32,7 @@
             [octet.spec.basic :as basic-spec]
             [octet.spec.string :as string-spec]
             [octet.spec.collections :as coll-spec]
+            [octet.spec.reference :as ref-spec]
             [octet.buffer :as buffer]))
 
 (util/defalias compose spec/compose)
@@ -41,6 +42,8 @@
 (util/defalias string string-spec/string)
 (util/defalias string* string-spec/string*)
 (util/defalias vector* coll-spec/vector*)
+(util/defalias ref-string* ref-spec/ref-string*)
+(util/defalias ref-bytes* ref-spec/ref-bytes*)
 (util/defalias int16 basic-spec/int16)
 (util/defalias uint16 basic-spec/uint16)
 (util/defalias int32 basic-spec/int32)

--- a/src/octet/spec/reference.cljc
+++ b/src/octet/spec/reference.cljc
@@ -1,0 +1,143 @@
+;; Copyright (c) 2015-2016 Andrey Antukh <niwi@niwi.nz>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; * Redistributions of source code must retain the above copyright notice, this
+;;   list of conditions and the following disclaimer.
+;;
+;; * Redistributions in binary form must reproduce the above copyright notice,
+;;   this list of conditions and the following disclaimer in the documentation
+;;   and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(ns octet.spec.reference
+  (:require [octet.buffer :as buffer]
+            [octet.spec :as spec]
+            [octet.spec.string :as string-spec]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Spec types for arbitrary length byte arrays/strings with a length reference
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- ref-size [type data]
+  (if (satisfies? spec/ISpecSize type)
+    (.size type)
+    (.size* type data)))
+
+(defn- coerce-types [types]
+  "to make it terser to handle both maps (assoc spec) and seq/vector
+  (indexed spec), we coerce the seq/vector types to maps where the
+  keys are indexes"
+  (cond (map? types) types
+        (or (seq? types)
+            (vector? types)) (apply array-map (interleave (range) types))
+        :else (throw (ex-info "invalid type structure, not map, seq or vector"
+                              {:type-structure types}))))
+
+(defn- ref-len-offset [ref-kw-or-index types data]
+  "for ref-xxxx* specs, calculate the byte offset of the
+  spec containing the length, i.e. (spec :a (int16) :b (int16) c: (ref-string* :b))
+  would cause this method to be called with :b (since the ref-string has a :b
+  reference as its length) and should then return 2 as the second int16 is at byte offset 2"
+  (reduce-kv
+    (fn [acc kw-or-index type]
+      (if (= ref-kw-or-index kw-or-index)
+        (reduced acc)
+        (+ acc (ref-size type (get data kw-or-index)))))
+    0
+    types))
+
+(defn- ref-write* [ref-kw-or-index buff pos value types data]
+  "write a ref spec, will also write the length to the length spec"
+  (let [input      (if (string? value) (string-spec/string->bytes value) value)
+        length     (count input)
+        types      (coerce-types types)
+        len-offset (ref-len-offset ref-kw-or-index types data)
+        len-type   (get types ref-kw-or-index)]
+    (.write len-type buff len-offset length)
+    (buffer/write-bytes buff pos length input)
+    (+ length)))
+
+(defn- ref-read* [ref-kw-or-index buff pos parent]
+  "read ref spec, will read the length from the length spec"
+  (let [datasize (cond (map? parent) (ref-kw-or-index parent)
+                       (or (seq? parent) (vector? parent)) (get parent ref-kw-or-index)
+                       :else (throw (ex-info
+                                      (str "bad ref-string*/ref-bytes* length reference  - " ref-kw-or-index)
+                                      {:length-kw ref-kw-or-index
+                                       :data-read parent})))
+        data     (buffer/read-bytes buff pos datasize)]
+    [datasize data]))
+
+(defn ref-bytes*
+  [ref-kw-or-index]
+  "create a dynamic length byte array where the length of the byte array is stored in another
+  spec within the containing indexed spec or associative spec. Example usages:
+  (spec (int16) (int16) (ref-bytes* 1))
+  (spec :a (int16) :b (int32) (ref-bytes* :b))
+  where the first example would store the length of the byte array in the second int16 and
+  the second example would store the length of the byte array in the int32 at key :b."
+  (reify
+    #?@(:clj
+        [clojure.lang.IFn
+         (invoke [s] s)]
+        :cljs
+        [cljs.core/IFn
+         (-invoke [s] s)])
+
+    spec/ISpecDynamicSize
+    (size* [_ data]
+      (count data))
+
+    spec/ISpecWithRef
+    (read* [_ buff pos parent]
+      (ref-read* ref-kw-or-index buff pos parent))
+
+    (write* [_ buff pos value types data]
+      (ref-write* ref-kw-or-index buff pos value types data))))
+
+(defn ref-string*
+  "create a dynamic length string  where the length of the string is stored in another
+  spec within the containing indexed spec or associative spec. Example usages:
+  (spec (int16) (int16) (ref-string* 1))
+  (spec :a (int16) :b (int32) (ref-string* :b))
+  where the first example would store the length of the string in the second int16 and
+  the second example would store the length of the string in the int32 at key :b."
+  [ref-kw-or-index]
+  (reify
+    #?@(:clj
+        [clojure.lang.IFn
+         (invoke [s] s)]
+        :cljs
+        [cljs.core/IFn
+         (-invoke [s] s)])
+
+    spec/ISpecDynamicSize
+    (size* [_ data]
+      (let [data (string-spec/string->bytes data)]
+        (count data)))
+
+    spec/ISpecWithRef
+    (read* [_ buff pos parent]
+      (let [[datasize bytes] (ref-read* ref-kw-or-index buff pos parent)]
+        [datasize (string-spec/bytes->string bytes datasize)]))
+
+    (write* [_ buff pos value types data]
+      (ref-write* ref-kw-or-index buff pos value types data))))
+
+(defn ref-vector*
+  [ref-kw-or-index]
+  ;; TODO: implement this
+  )

--- a/src/octet/util.cljc
+++ b/src/octet/util.cljc
@@ -22,7 +22,9 @@
 ;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(ns octet.util)
+(ns octet.util
+  (:require [clojure.string :as str :refer [join ]])
+  (:import [java.util.Arrays]))
 
 (defmacro defalias
   [sym sym2]
@@ -30,4 +32,124 @@
      (def ~sym ~sym2)
      (alter-meta! (var ~sym) merge (dissoc (meta (var ~sym2)) :name))))
 
+(defn assoc-ordered [a-map key val & rest]
+  "assoc into an array-map, keeping insertion order. The normal clojure
+  assoc function switches to hash maps on maps > size 10 and loses insertion order"
+  (let [kvs (interleave (concat (keys a-map) (list key))
+                        (concat (vals a-map) (list val)))
+        ret (apply array-map kvs)]
+    (if rest
+      (if (next rest)
+        (recur ret (first rest) (second rest) (nnext rest))
+        (throw (IllegalArgumentException.
+                 "assoc-ordered expects even number of arguments after map/vector, found odd number")))
+      ret)))
 
+;;
+;; Hexdumps
+;;
+
+
+(defn- bytes->hex [^bytes bytes]
+  "converts a byte array to a hex string"
+  (let [[f & r] bytes
+        fh (fn [_ b]
+             (let [h (Integer/toHexString (bit-and b 0xFF))]
+               (if (<= 0 b 15) (str "0" h) h)))]
+    (join (reductions fh (fh 0 f) r))))
+
+(defn- byte->ascii [byte]
+  "convert a byte to 'printable' ascii where possible, otherwise ."
+  (if (<= 32 (bit-and byte 0xFF) 127) (char byte) \.))
+
+(defn- bytes->ascii [^bytes bytes]
+  "returns a 16-per-line printable ascii view of the bytes"
+  (->> bytes
+       (map byte->ascii)
+       (partition 16 16 "                ")
+       (map join)))
+
+(defn- format-hex-line [^String hex-line]
+  "formats a 'line' (32 hex chars) of hex output"
+  (->> hex-line
+       (partition-all 4)
+       (map join)
+       (split-at 4)
+       (map #(join " " %))
+       (join "  ")))
+
+(defn- bytes->hexdump [^bytes bytes]
+  "formats a byte array to a sequence of formatted hex lines"
+  (->> bytes
+       bytes->hex
+       (partition 32 32 (join (repeat 32 " ")))
+       (map format-hex-line)))
+
+(defn- copy-bytes [bytes offset size]
+  "utility function - copy bytes, return new byte array"
+  (let [size (if (nil? size) (alength bytes) size)]
+    (if (and (= 0 offset) (= (alength bytes) size))
+      bytes                                                 ; short circuit
+      (java.util.Arrays/copyOfRange bytes
+                                    offset
+                                  (+ offset size)))))
+
+(defn get-dump-bytes [x offset size]
+  "utility function - return byte array from offset offset and with
+  size size for nio ByteBuffer, netty ByteBuf, byte array, and String"
+  (cond (and (satisfies? octet.buffer/IBufferBytes x)
+             (satisfies? octet.buffer/IBufferLimit x))
+        (let [size (if (nil? size) (octet.buffer/get-capacity x) size)]
+          (octet.buffer/read-bytes x offset size))
+
+        (instance? (type (byte-array 0)) x)
+        (copy-bytes x offset size)
+
+        (instance? String x)
+        (copy-bytes (.getBytes x) offset size)))
+
+
+; Example usage of hex-dump
+;
+;(hex-dump (byte-array (range 200)))
+; --------------------------------------------------------------------
+;|00000000: 0001 0203 0405 0607  0809 0a0b 0c0d 0e0f  ................|
+;|00000010: 1011 1213 1415 1617  1819 1a1b 1c1d 1e1f  ................|
+;|00000020: 2021 2223 2425 2627  2829 2a2b 2c2d 2e2f   !"#$%&'()*+,-./|
+;|00000030: 3031 3233 3435 3637  3839 3a3b 3c3d 3e3f  0123456789:;<=>?|
+;|00000040: 4041 4243 4445 4647  4849 4a4b 4c4d 4e4f  @ABCDEFGHIJKLMNO|
+;|00000050: 5051 5253 5455 5657  5859 5a5b 5c5d 5e5f  PQRSTUVWXYZ[\]^_|
+;|00000060: 6061 6263 6465 6667  6869 6a6b 6c6d 6e6f  `abcdefghijklmno|
+;|00000070: 7071 7273 7475 7677  7879 7a7b 7c7d 7e7f  pqrstuvwxyz{|}~|
+;|00000080: 8081 8283 8485 8687  8889 8a8b 8c8d 8e8f  ................|
+;|00000090: 9091 9293 9495 9697  9899 9a9b 9c9d 9e9f  ................|
+;|000000a0: a0a1 a2a3 a4a5 a6a7  a8a9 aaab acad aeaf  ................|
+;|000000b0: b0b1 b2b3 b4b5 b6b7  b8b9 babb bcbd bebf  ................|
+;|000000c0: c0c1 c2c3 c4c5 c6c7                       ........        |
+; --------------------------------------------------------------------
+
+(defn hex-dump
+  "Create hex dump. Accepts byte array, java.nio.ByteBuffer,
+  io.netty.buffer.ByteBuf, or String as first argument. Offset will
+  start the dump from an offset in the byte array, size will limit
+  the number of bytes dumped, and frames will print a frame around
+  the dump if true. Set print to true to print the dump on stdout
+  (default) or false to return it as a string. Example call:
+  (hex-dump (byte-array (range 200)) :print false)"
+  [x & {:keys [offset size print frame]
+                   :or   {offset 0
+                          print  true
+                          frame true}}]
+  {:pre [(not (nil? x))]}
+  (let [bytes (get-dump-bytes x offset size)
+        size (if (nil? size) (alength bytes) size)
+        dump (bytes->hexdump bytes)
+        ascii (bytes->ascii bytes)
+        offs (map #(format "%08x" %)
+                  (range offset (+ offset size 16) 16))
+        header (str " " (join (repeat 68 "-")))
+        border (if frame "|" "")
+        lines (map #(str border %1 ": " %2 "  " %3 border) offs dump ascii)
+        lines (if frame (concat [header] lines [header]) lines)
+        result (join \newline lines)]
+    (if print (println result) result)))

--- a/src/octet/util.cljc
+++ b/src/octet/util.cljc
@@ -50,7 +50,7 @@
 ;;
 
 
-(defn- bytes->hex [^bytes bytes]
+(defn bytes->hex [^bytes bytes]
   "converts a byte array to a hex string"
   (let [[f & r] bytes
         fh (fn [_ b]
@@ -58,7 +58,7 @@
                (if (<= 0 b 15) (str "0" h) h)))]
     (join (reductions fh (fh 0 f) r))))
 
-(defn- byte->ascii [byte]
+(defn byte->ascii [byte]
   "convert a byte to 'printable' ascii where possible, otherwise ."
   (if (<= 32 (bit-and byte 0xFF) 127) (char byte) \.))
 


### PR DESCRIPTION
Adding support for dynamic specs where the length is stored in another spec, fixing a size issue with assoc spec, adding hex-dump function, set version to 1.0.2.

Input welcomed as I am somewhat new to clojure and some of the additions touch the core design of the library. 

The reason for adding this is that a lot of binary formats out there do not store the string/byte-array/x length immediately preceding the data. Also the size of the length field (i.e. inte16 vs int32 etc) varies from binary format to binary format and can not be known beforehand. 

Real world example from the [zip file specification](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) which I'm currently parsing with octet: 

```
 central file header signature   4 bytes  (0x02014b50)
        version made by                 2 bytes
        version needed to extract       2 bytes
        general purpose bit flag        2 bytes
        compression method              2 bytes
        last mod file time              2 bytes
        last mod file date              2 bytes
        crc-32                          4 bytes
        compressed size                 4 bytes
        uncompressed size               4 bytes
        file name length                2 bytes
        extra field length              2 bytes
        file comment length             2 bytes
        disk number start               2 bytes
        internal file attributes        2 bytes
        external file attributes        4 bytes
        relative offset of local header 4 bytes

        file name (variable size)
        extra field (variable size)
        file comment (variable size)
```
note thte file name (ref-string*), extra-field (ref-bytes*) and file comment (ref-string*) fields and their corresponding length fields further up in the specification. Using the new spec types in this pull request, the above could be represented as: 

```
  (spec                                                     ; size 46 + string lengths
    :cdr-header-signature         int32
    :version-made-by              int16
    :version-needed-to-extract    int16
    :general-purpose              int16
    :compression-method           int16
    :last-mod-file-time           int16
    :last-mod-file-date           int16
    :crc-32                       int32
    :compressed-size              int32
    :uncompressed-size            int32
    :file-name-length             int16
    :extra-field-length           int16
    :file-comment-length          int16
    :disk-number-start            int16
    :internal-file-attributes     int16
    :external-file-attributes     int32
    :relative-offset-local-header int32
    
    :file-name                    (ref-string* :file-name-length)
    :extra-field                  (ref-bytes* :extra-field-length)
    :file-comment                 (ref-string* :file-comment-length)))
```
This pr also supports the equivalent syntax for indexed specs, replacing the keyword references with long indexes. 

Also adding a hex-dump function, example usage: 
```
(hex-dump (byte-array (range 250))
          :offset 10
          :size 240
          :frame true
          :print true)
 --------------------------------------------------------------------
|0000000a: 0a0b 0c0d 0e0f 1011  1213 1415 1617 1819  ................|
|0000001a: 1a1b 1c1d 1e1f 2021  2223 2425 2627 2829  ...... !"#$%&'()|
|0000002a: 2a2b 2c2d 2e2f 3031  3233 3435 3637 3839  *+,-./0123456789|
|0000003a: 3a3b 3c3d 3e3f 4041  4243 4445 4647 4849  :;<=>?@ABCDEFGHI|
|0000004a: 4a4b 4c4d 4e4f 5051  5253 5455 5657 5859  JKLMNOPQRSTUVWXY|
|0000005a: 5a5b 5c5d 5e5f 6061  6263 6465 6667 6869  Z[\]^_`abcdefghi|
|0000006a: 6a6b 6c6d 6e6f 7071  7273 7475 7677 7879  jklmnopqrstuvwxy|
|0000007a: 7a7b 7c7d 7e7f 8081  8283 8485 8687 8889  z{|}~..........|
|0000008a: 8a8b 8c8d 8e8f 9091  9293 9495 9697 9899  ................|
|0000009a: 9a9b 9c9d 9e9f a0a1  a2a3 a4a5 a6a7 a8a9  ................|
|000000aa: aaab acad aeaf b0b1  b2b3 b4b5 b6b7 b8b9  ................|
|000000ba: babb bcbd bebf c0c1  c2c3 c4c5 c6c7 c8c9  ................|
|000000ca: cacb cccd cecf d0d1  d2d3 d4d5 d6d7 d8d9  ................|
|000000da: dadb dcdd dedf e0e1  e2e3 e4e5 e6e7 e8e9  ................|
|000000ea: eaeb eced eeef f0f1  f2f3 f4f5 f6f7 f8f9  ................|
 --------------------------------------------------------------------
```

details:
- changed the map containing the assoc spec from hash map 
  to array map so that it keeps insertion order even for assoc 
  specs larger than 10. Implemented assoc-ordered in 
  octet.util to support modifications
- added a new protocol ISpecWithRef which is an either-or
  with ISpec. Not sure about the best way to model this,
  input welcomed. ISpecWithRef indicates that the spec 
  needs to know about its surrounding AssociativeSpec or 
  IndexedSpec as the size of the spec is stored in another 
  spec in the surrounding spec. 
- added new code to AssociativeSpec and IndexedSpec to
  support the new ISpecWithRef type of spec where the
  contained spec needs to be aware of the containers
  data / structure.
- added new spec types ref-string* and ref-bytes* for
  dynamic types where the length is stored in another
  spec.
- added a hex-dump function capable of printing a human
  readable dump of nio ByteBuffers, netty ByteBufs, byte
  arrays, and Strings. Buffy has this and as I like octet
  better and find it extremely useful I figured it would be
  a good addition. Compared to the buffy one, this 
  implementation is faster, terser, and more
  configurable.
- added tests for the new ref spec types.

Not done: documentation. Will add documentation if this pull request is deemed sane. 