### PR TITLE
Fix warnings about illegal reflective access operations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://unlicense.org/"}
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [org.clojure/clojurescript "1.9.946" :scope "provided"]
-                 [io.netty/netty-buffer "4.1.5.Final"]]
+                 [io.netty/netty-buffer "4.1.24.Final"]]
 
   :source-paths ["src"]
   :test-paths ["test"]


### PR DESCRIPTION
Running on Java 9, I'm seeing warnings about illegal reflective access.  Upgrading Netty cleared them up.

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by io.netty.util.internal.PlatformDependent0$1 (file:/Users/hitesh/.m2/repository/io/netty/netty-common/4.1.5.Final/netty-common-4.1.5.Final.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of io.netty.util.internal.PlatformDependent0$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
