### PR TITLE
Fix ns spec failure for clj v1.10.0

### DIFF
--- a/src/octet/util.cljc
+++ b/src/octet/util.cljc
@@ -26,7 +26,7 @@
   (:require [clojure.string :as str :refer [join]]
             [octet.buffer :as bfr])
 
-  #?(:clj (:import [java.util.Arrays])))
+  #?(:clj (:import java.util.Arrays)))
 
 (defmacro defalias
   [sym sym2]


### PR DESCRIPTION
Fixes #14 

Either `(:import [java.util Arrays])` or `(:import java.util.Arrays)` fixes it.  
I went with the latter as this style is used in src/octet/buffer.cljc as well.