### PR TITLE
Update clojurescript and netty-buffer dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "Public Domain"
             :url "http://unlicense.org/"}
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
-                 [org.clojure/clojurescript "1.10.339" :scope "provided"]
-                 [io.netty/netty-buffer "4.1.30.Final"]]
+                 [org.clojure/clojurescript "1.10.773" :scope "provided"]
+                 [io.netty/netty-buffer "4.1.52.Final"]]
 
   :source-paths ["src"]
   :test-paths ["test"]


### PR DESCRIPTION
The existing dependencies were outdated, and contained the following security issues:

guava-22.0.jar                                    CVE-2018-10237
netty-common-4.1.30.Final.jar         CVE-2020-11612, CVE-2019-20444, CVE-2019-20445, CVE-2019-16869
protobuf-java-3.0.2.jar                      CVE-2015-5237