### PR TITLE
Various type hints for GraalVM native image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ pom.xml.asc
 /out
 /*-init.clj
 /doc/dist/
+.cpcache/
+/cljs-test-runner-out/
+.calva/
+.clj-kondo/

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,16 @@
+{:paths ["src"]
+ :deps
+ {org.clojure/clojure {:mvn/version "1.9.0"}
+  org.clojure/clojurescript {:mvn/version "1.10.339"}
+  io.netty/netty-buffer {:mvn/version "4.1.30.Final"}}
+ :aliases {:dev {:extra-paths ["test"]
+                 :extra-deps {org.clojure/tools.namespace {:mvn/version "0.3.1"}}}
+           :test {:extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                          :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
+                  :main-opts ["-m" "cognitect.test-runner"
+                              "-r" "^octet\\.tests\\..*"]}
+           :test-cljs {:extra-deps {olical/cljs-test-runner {:mvn/version "3.7.0"}}
+                       :main-opts ["-m" "cljs-test-runner.main"
+                                   "-r" "^octet\\.tests\\..*"]}
+           :outdated {:extra-deps {olical/depot {:mvn/version "1.8.2"}}
+                      :main-opts ["-m" "depot.outdated.main"]}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/octet "1.1.2"
+(defproject funcool/octet "1.1.3-SNAPSHOT"
   :description "A clojure(script) library for work with binary data."
   :url "https://github.com/funcool/octet"
   :license {:name "Public Domain"

--- a/src/octet/buffer.cljc
+++ b/src/octet/buffer.cljc
@@ -33,7 +33,8 @@
   with support for nio bytebuffers, netty41 bytebuffers and
   es6 typed arrays (from javascript environments)."
   #?(:clj
-     (:import java.nio.ByteBuffer
+     (:import java.nio.Buffer
+              java.nio.ByteBuffer
               java.nio.ByteOrder
               io.netty.buffer.ByteBuf
               io.netty.buffer.ByteBufAllocator)))
@@ -90,8 +91,8 @@
    (defn- set-current-bytebuffer-byte-order!
      [buff]
      (case *byte-order*
-       :big-endian (.order buff ByteOrder/BIG_ENDIAN)
-       :little-endian (.order buff ByteOrder/LITTLE_ENDIAN))))
+       :big-endian (.order ^ByteBuffer buff ByteOrder/BIG_ENDIAN)
+       :little-endian (.order ^ByteBuffer buff ByteOrder/LITTLE_ENDIAN))))
 
 #?(:clj
    (extend-type ByteBuffer
@@ -163,13 +164,13 @@
      IBufferByte
      (read-byte [buff pos]
        (set-current-bytebuffer-byte-order! buff)
-       (.get buff pos))
+       (.get buff ^Long pos))
      (write-byte [buff pos value]
        (set-current-bytebuffer-byte-order! buff)
        (.put buff pos value))
      (read-ubyte [buff pos]
        (set-current-bytebuffer-byte-order! buff)
-       (let [val (.get buff pos)]
+       (let [val (.get ^Long buff pos)]
          (bit-and 0xFF (short val))))
      (write-ubyte [buff pos value]
        (set-current-bytebuffer-byte-order! buff)
@@ -180,15 +181,15 @@
      (read-bytes [buff pos size]
        (let [tmpbuf (byte-array size)
              oldpos (.position buff)]
-         (.position buff pos)
+         (.position ^Buffer buff ^Long pos)
          (.get buff tmpbuf)
-         (.position buff oldpos)
+         (.position ^Buffer buff oldpos)
          tmpbuf))
      (write-bytes [buff pos size data]
-       (let [oldpos (.position buff)]
-         (.position buff pos)
+       (let [oldpos (.position ^Buffer buff)]
+         (.position ^Buffer buff ^Long pos)
          (.put buff data 0 size)
-         (.position buff oldpos)))
+         (.position ^Buffer buff oldpos)))
 
      IBufferLimit
      (get-capacity [buff]
@@ -280,10 +281,10 @@
      IBufferBytes
      (read-bytes [buff pos size]
        (let [tmpbuf (byte-array size)]
-         (.getBytes buff pos tmpbuf)
+         (.getBytes buff ^Long pos tmpbuf)
          tmpbuf))
      (write-bytes [buff pos size data]
-       (.setBytes buff pos data 0 size))
+       (.setBytes buff ^Long pos data 0 ^Long size))
 
      IBufferLimit
      (get-capacity [buff]

--- a/src/octet/spec/string.cljc
+++ b/src/octet/spec/string.cljc
@@ -36,7 +36,7 @@
   [input]
   (let [mark (byte 0)]
     (reduce (fn [sum index]
-              (let [value (aget input index)]
+              (let [value (aget ^bytes input index)]
                 (if (= value mark)
                   (inc sum)
                   (reduced sum))))


### PR DESCRIPTION
Hi there,

I have been using octet in my project for some time, but when I recently migrated from a JavaScript/NodeJS runtime to a Java/GraalVM runtime, I found that various type hints were needed in order for the GraalVM `native-image` command to build working executables.

I also included a `deps.edn` file so that downstream projects can use git deps, which is easier than interacting with Maven repositorites and Clojars etc etc.

Thanks 🙂