### PR TITLE
Adding c-string (null terminated strings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pom.xml.asc
 /out
 /*-init.clj
 /doc/dist/
+.lsp

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/octet "1.1.2"
+(defproject funcool/octet "1.1.3"
   :description "A clojure(script) library for work with binary data."
   :url "https://github.com/funcool/octet"
   :license {:name "Public Domain"

--- a/src/octet/core.cljc
+++ b/src/octet/core.cljc
@@ -39,6 +39,7 @@
 (util/defalias spec spec/spec)
 (util/defalias size spec/size)
 (util/defalias repeat spec/repeat)
+(util/defalias cstring string-spec/cstring)
 (util/defalias string string-spec/string)
 (util/defalias string* string-spec/string*)
 (util/defalias vector* coll-spec/vector*)

--- a/src/octet/spec/string.cljc
+++ b/src/octet/spec/string.cljc
@@ -185,7 +185,7 @@
       (loop [index pos acc []]
         (let [b (buffer/read-byte buff index)]
           (if (zero? b)
-            [(+ index 1) (bytes->string (byte-array acc) index)]
+            [(inc (count acc)) (bytes->string (byte-array acc) (count acc))]
             (recur (inc index) (conj acc b))))))
 
     (write [_ buff pos value]

--- a/src/octet/spec/string.cljc
+++ b/src/octet/spec/string.cljc
@@ -164,3 +164,32 @@
         (buffer/write-int buff pos length)
         (buffer/write-bytes buff (+ pos 4) length input)
         (+ length 4)))))
+
+(def ^{:doc "Arbitrary length cstring (null-terminated string) type spec."}
+  cstring
+  (reify
+    #?@(:clj
+        [clojure.lang.IFn
+         (invoke [s] s)]
+        :cljs
+        [cljs.core/IFn
+         (-invoke [s] s)])
+
+    spec/ISpecDynamicSize
+    (size* [_ data]
+      (let [data (string->bytes data)]
+        (+ 1 (count data))))
+
+    spec/ISpec
+    (read [_ buff pos]
+      (loop [index pos acc []]
+        (let [b (buffer/read-byte buff index)]
+          (if (zero? b)
+            [(+ index 1) (bytes->string (byte-array acc) index)]
+            (recur (inc index) (conj acc b))))))
+
+    (write [_ buff pos value]
+      (let [input (string->bytes (str value "\0"))
+            length (count input)]
+        (buffer/write-bytes buff pos length input)
+        length))))

--- a/test/octet/tests/core.cljc
+++ b/test/octet/tests/core.cljc
@@ -250,11 +250,11 @@
 
 (t/deftest spec-data-with-cstring-single
   (let [spec (buf/spec (buf/cstring))
-        buffer (buf/allocate 13)]
-    (buf/write! buffer ["hello world!"] spec)
+        buffer (buf/allocate 11)]
+    (buf/write! buffer ["1234567890"] spec)
     (let [[readed data] (buf/read* buffer spec)]
-        (t/is (= readed 13))
-        (t/is (= data  ["hello world!"])))))
+        (t/is (= readed 11))
+        (t/is (= data  ["1234567890"])))))
 
 (t/deftest spec-data-with-dynamic-types-single
   (let [spec (buf/spec (buf/string*))
@@ -272,13 +272,37 @@
       (t/is (= readed 18))
       (t/is (= data ["1234567890" 1000])))))
 
-(t/deftest spec-data-with-cstring-and-dynamic-types-combined
+(t/deftest spec-data-with-cstring-and-other-types-combined
   (let [spec (buf/spec (buf/cstring) (buf/int32))
         buffer (buf/allocate 40)]
-    (buf/write! buffer ["hello world!" 1000] spec)
+    (buf/write! buffer ["1234567890" 1000] spec)
     (let [[readed data] (buf/read* buffer spec)]
-      (t/is (= readed 17))
-      (t/is (= data  ["hello world!" 1000])))))
+      (t/is (= readed 15))
+      (t/is (= data  ["1234567890" 1000])))))
+
+(t/deftest spec-data-with-multi-cstring
+  (let [spec (buf/spec buf/cstring buf/cstring)
+        buffer (buf/allocate 40)]
+    (buf/write! buffer ["1234567890" "1234567890"] spec)
+    (let [[readed data] (buf/read* buffer spec)]
+      (t/is (= readed 22))
+      (t/is (= data  ["1234567890" "1234567890"])))))
+
+(t/deftest spec-data-with-types-and-cstring-combined
+  (let [spec (buf/spec buf/cstring buf/int32 buf/byte buf/cstring)
+        buffer (buf/allocate 40)]
+    (buf/write! buffer ["1234567890" 1000  1 "1234567890"] spec)
+    (let [[readed data] (buf/read* buffer spec)]
+      (t/is (= readed 27))
+      (t/is (= data  ["1234567890" 1000  1 "1234567890"])))))
+
+(t/deftest spec-data-with-multi-cstring-and-dynamic-types-combined
+  (let [spec (buf/spec (buf/int32) (buf/cstring) (buf/cstring) (buf/int32))
+        buffer (buf/allocate 40)]
+    (buf/write! buffer [9999 "12345" "67890" 1000] spec)
+    (let [[readed data] (buf/read* buffer spec)]
+      (t/is (= readed 20))
+      (t/is (= data  [9999 "12345" "67890" 1000])))))
 
 (t/deftest spec-data-with-indexed-ref-string-single
   (let [spec (buf/spec (buf/int32)

--- a/test/octet/tests/core.cljc
+++ b/test/octet/tests/core.cljc
@@ -248,6 +248,14 @@
                    :else
                    (t/is (= data data')))))))))))
 
+(t/deftest spec-data-with-cstring-single
+  (let [spec (buf/spec (buf/cstring))
+        buffer (buf/allocate 13)]
+    (buf/write! buffer ["hello world!"] spec)
+    (let [[readed data] (buf/read* buffer spec)]
+        (t/is (= readed 13))
+        (t/is (= data  ["hello world!"])))))
+
 (t/deftest spec-data-with-dynamic-types-single
   (let [spec (buf/spec (buf/string*))
         buffer (buf/allocate 20)]
@@ -263,6 +271,14 @@
     (let [[readed data] (buf/read* buffer spec)]
       (t/is (= readed 18))
       (t/is (= data ["1234567890" 1000])))))
+
+(t/deftest spec-data-with-cstring-and-dynamic-types-combined
+  (let [spec (buf/spec (buf/cstring) (buf/int32))
+        buffer (buf/allocate 40)]
+    (buf/write! buffer ["hello world!" 1000] spec)
+    (let [[readed data] (buf/read* buffer spec)]
+      (t/is (= readed 17))
+      (t/is (= data  ["hello world!" 1000])))))
 
 (t/deftest spec-data-with-indexed-ref-string-single
   (let [spec (buf/spec (buf/int32)


### PR DESCRIPTION
Automatically appends the null terminator to strings. 

```clj
(def buffer (buf/allocate 6))
(buf/write! buffer "hello" buf/cstring)
(buf/read buffer buf/cstring)
```